### PR TITLE
Make `TagInput` a controlled component. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,27 @@ The props are very straightforward.
 |-----|------|-------------|--------|
 |addNew|boolean|If true, allows the user to create new tags that are not set in the dataset|true|
 |categories|Array of objects|Dataset with categories and items|Required|
-|transformTag|function|A function that will receive the category id and the selected item and must return a string. This string will be the resultant string. Useful if you need to apply a transformation to the tags.|item is resulting tag|
-|value|Array of strings|Array with the initial tags|[]|
+|transformTag|function|A function that will receive the tag object (which has at least keys `title` and `category`) and must return a string. This string will be displayed to the user. Useful if you need to apply a transformation to the tags.|(tag) => tag.title|
+|value|Array of tags. Tags are objects with (at least) keys `title` and `category`, where `category` is the id of a category in the array passed in for the `categories` prop|Array with the initial tags|[]|
 |onBlur|function|Callback for when the input loses focus|noop|
 |onChange|function|Callback for when the input changes. It does not get an event as parameter, it gets the array of tags after the change.|noop|
 |placeholder|string|A placeholder will be given in the input box.|Add a tag|
+<<<<<<< 22655e46e0cf6c9a5da5a9ed5322e8dc95a90169
 |getTagStyle|function| A function from the tag text (string) to an object with any or all of the following keys: `base`, `content` and `delete`. The values are React style objects. This example renders 1-letter long tags in red: `text => text.length === 1 ? {base: {color: "red"}} : {}` | () => ({}) |
 |getCreateNewText|function| A function that returns the text to display when the user types an unrecognized tag, given a title and text.| (title, text) => `Create new ${title} "${text}"` |
+=======
+|getTagStyle|function| A function from the tag (object with at least the keys `title` and `category`) to an object with any or all of the following keys: `base`, `content` and `delete`. The values are React style objects. This example renders 1-letter long tags in red: `text => text.length === 1 ? {base: {color: "red"}} : {}` | () => ({}) |
+
+#### The tag object
+Tag objects look like this:
+```
+{
+	title: 'String to used to identify the tag',
+	category: 'id of the category for the tag'
+
+}
+```
+>>>>>>> Make `TagInput` a controlled component. Fixes #11
 
 #### The category object
 The category object for the dataset looks like this:

--- a/index.js
+++ b/index.js
@@ -30,42 +30,37 @@ const categories = [
   }
 ];
 
-function transformTag(category, item) {
-  return `${category}/${item}`;
+function transformTag(tag) {
+  const categoryMatches = categories.filter(category => category.id === tag.category);
+  const categoryTitle = categoryMatches[0].title;
+  return `${categoryTitle}/${tag.title}`;
 }
 
-const props = {
-  addNew: true,
-  categories,
-  transformTag,
-  value: ['initial'],
-  placeholder: "Add a tag",
-  onChange(tags) {
-    console.log('Changed', tags);
-  },
-  onBlur() {
-    console.log('Blur');
-  },
-  getTagStyle(text){
-    if (text === "initial") {
-      return {
-        base: {
-          backgroundColor: "gray",
-          color: "lightgray"
-        }
+
+function getTagStyle(tag){
+  if (tag.title === "rhino") {
+    return {
+      base: {
+        backgroundColor: "gray",
+        color: "lightgray"
       }
     }
     return {}
-  },
-  getCreateNewText(title, text){
-    return `create new ${title} "${text}"`
   }
-};
+}
+
+function getCreateNewText(title, text){
+  return `create new ${title} "${text}"`
+}
 
 const Wrap = React.createClass({
   getInitialState() {
     return {
-      editable: true
+      editable: true,
+      tags: [{
+        title: "rhino",
+        category: 'animals'
+      }]
     };
   },
 
@@ -79,7 +74,24 @@ const Wrap = React.createClass({
     return (
       <div>
         <button onClick={this.toggleEdit}>Toggle edit</button>
-        {this.state.editable ? <Input {...props} /> : <span>Not editable</span>}
+        {this.state.editable
+                      ? <Input
+                          addNew={true}
+                          categories={categories}
+                          getTagStyle={getTagStyle}
+                          value={this.state.tags}
+                          placeholder="Add a tag"
+                          onChange={(tags) => {
+                            console.log('Changed', tags);
+                            this.setState({tags});
+                          }}
+                          onBlur={() => {
+                            console.log('Blur');
+                          }}
+                          transformTag={transformTag}
+                          getCreateNewText={getCreateNewText}
+                        /> 
+                      : <span>Not editable</span>}
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-categorized-tag-input",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "React.js component for making tag autocompletion inputs with categorized results.",
   "main": "categorized-tag-input.js",
   "scripts": {

--- a/src/CategorizedTagInput.jsx
+++ b/src/CategorizedTagInput.jsx
@@ -25,7 +25,7 @@ const CategorizedTagInput = React.createClass({
     addNew: PropTypes.bool,
     categories: PropTypes.arrayOf(PropTypes.object).isRequired,
     transformTag: PropTypes.func,
-    value: PropTypes.arrayOf(PropTypes.string),
+    value: PropTypes.arrayOf(PropTypes.object),
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
     placeholder: PropTypes.string,
@@ -41,10 +41,17 @@ const CategorizedTagInput = React.createClass({
         category: 0
       },
       panelOpened: false,
-      tags: this.props.value || [],
       categories: [],
       addNew: this.props.addNew === undefined ? true : this.props.addNew
     };
+  },
+
+  getDefaultProps() {
+      return {
+          onChange(newTags){
+            // do nothing
+          }
+      };
   },
 
   componentWillMount() {
@@ -116,34 +123,20 @@ const CategorizedTagInput = React.createClass({
   },
 
   onTagDeleted(i) {
-    let newTags = this.state.tags.slice(0, i)
-      .concat(this.state.tags.slice(i+1));
-    this.setState({
-      tags: newTags
-    });
-
-    if (typeof this.props.onChange === 'function') {
-      this.props.onChange(newTags);
-    }
+    const newTags = this.props.value.slice()
+    newTags.splice(i, 1)
+    this.props.onChange(newTags)
   },
 
-  onAdd(newTag) {
-    let { category, item } = newTag;
-    if (typeof this.props.transformTag === 'function') {
-      item = this.props.transformTag(category, item);
-    }
-
-    let newTags = this.state.tags.concat([item]);
+  onAdd(newTag) {  
+    const newTags = this.props.value.concat([newTag]);
     this.setState({
-      tags: newTags,
       value: '',
       panelOpened: true
     });
 
     this.refs.input.focusInput();
-    if (typeof this.props.onChange === 'function') {
-      this.props.onChange(newTags);
-    }
+    this.props.onChange(newTags);
   },
 
   addSelectedTag() {
@@ -151,18 +144,18 @@ const CategorizedTagInput = React.createClass({
       return;
     }
 
-    let category = this.state.categories[this.state.selection.category];
-    let item = category.items[this.state.selection.item];
+    const category = this.state.categories[this.state.selection.category];
+    const title = category.items[this.state.selection.item];
     this.onAdd({
       category: category.id,
-      item: item || this.state.value
+      title: title || this.state.value
     });
   },
 
   handleBackspace(e) {
     if (this.state.value.trim().length === 0) {
       e.preventDefault();
-      this.onTagDeleted(this.state.tags.length - 1);
+      this.onTagDeleted(this.props.value.length - 1);
     }
   },
 
@@ -232,10 +225,6 @@ const CategorizedTagInput = React.createClass({
     }
   },
 
-  value() {
-    return this.state.tags;
-  },
-
   render() {
     return (
       <div className='cti__root'>
@@ -243,7 +232,9 @@ const CategorizedTagInput = React.createClass({
           onValueChange={this.onValueChange} onTagDeleted={this.onTagDeleted}
           onKeyDown={this.onKeyDown} placeholder={this.props.placeholder} value={this.state.value}
           getTagStyle={this.props.getTagStyle}
-          tags={this.state.tags} onBlur={this.props.onBlur} ref='input' />
+          tags={this.props.value}
+          transformTag={this.props.transformTag}
+          onBlur={this.props.onBlur} ref='input' />
         {this.state.panelOpened && this.state.value.length > 0 ? <Panel categories={this.state.categories}
           selection={this.state.selection} onAdd={this.onAdd}
           input={this.state.value}

--- a/src/Input.jsx
+++ b/src/Input.jsx
@@ -12,26 +12,37 @@ const Input = React.createClass({
     onTagDeleted: PropTypes.func.isRequired,
     onKeyDown: PropTypes.func.isRequired,
     value: PropTypes.string.isRequired,
-    tags: PropTypes.arrayOf(PropTypes.string).isRequired,
+    tags: PropTypes.arrayOf(PropTypes.object).isRequired,
     placeholder: PropTypes.string,
     onBlur: PropTypes.func,
-    getTagStyle: PropTypes.func
+    getTagStyle: PropTypes.func,
+    transformTag: PropTypes.func
   },
 
   focusInput() {
     this.refs.input.focus();
   },
 
+  getDefaultProps() {
+      return {
+          getTagStyle(tag) {
+            // empty style object by default
+            return {};
+          },
+          transformTag(tag){
+            return tag.title;
+          }
+      };
+  },
+
   getTags() {
 
-    const getTagStyle = this.props.getTagStyle || () => {}
-
-    return this.props.tags.map((t, i) => {
+    return this.props.tags.map((tag, i) => {
       return (
-        <Tag selected={false} input='' text={t} addable={false}
-          deletable={true} key={t + '_' + i}
+        <Tag selected={false} input='' text={this.props.transformTag(tag)} addable={false}
+          deletable={true} key={tag.title + '_' + i}
           onDelete={() => this.props.onTagDeleted(i)} 
-          style={getTagStyle(t)}/>
+          style={this.props.getTagStyle(tag)}/>
       );
     });
   },

--- a/src/Tag.jsx
+++ b/src/Tag.jsx
@@ -14,6 +14,13 @@ const Tag = React.createClass({
     style: PropTypes.object
   },
 
+  // helps tests pass
+  getDefaultProps() {
+      return {
+          text: ''  
+      };
+  },
+
   tagContent() {
     let content = [];
     let startIndex = this.props.text.trim().toLowerCase()


### PR DESCRIPTION
Fixes #11

Major breaking changes:
- `TagInput` is a controlled component and does not maintain tags in its state
- `transformTag`, `onChange` and `getTagStyle` now work on tag objects, not strings

I found in implementation that letting the component work as both controlled and 
uncontrolled introduced a ton of complexity so here's a PR for making `TagInput`
a controlled component.

I also discovered that `transformTag` is really useful: without it, the user of this library would
have to implement encoding and decoding of tag metadata (including category) to/from strings,
which seems like too much effort for something that should be trivial.

Using an array of objects for tags rather than an array of strings, together with `transformTag`,
provides a simple and flexible way to track the state and control what text the user sees. The objects
also allow adding arbitrary data to tags, which could be useful for things like controlling the tag style.

Looking forward to your feedback!
