### PR TITLE
Fix click-to-add

### DIFF
--- a/src/Category.jsx
+++ b/src/Category.jsx
@@ -25,11 +25,11 @@ const Category = React.createClass({
     getCreateNewText: PropTypes.func
   },
 
-  onAdd(item) {
+  onAdd(title) {
     return () => {
       this.props.onAdd({
         category: this.props.category,
-        item: item
+        title: title
       });
     };
   },

--- a/test/Category_spec.js
+++ b/test/Category_spec.js
@@ -102,11 +102,11 @@ describe('Category', () => {
   });
 
   describe('when a tag is clicked', () => {
-    it('should trigger onAdd with category and item', done => {
+    it('should trigger onAdd with category and title', done => {
       let c = category(props({
         onAdd(o) {
           expect(o.category).toBe(1);
-          expect(o.item).toBe('foo');
+          expect(o.title).toBe('foo');
           done();
         }
       }));


### PR DESCRIPTION
When typing a tag name, a list of suggestions displays in the panel
Previously, clicking a suggestion did not correctly add the tag to the list,
since tag title was `undefined`.

This commit fixes the issue
